### PR TITLE
Update statistics_volume_pipeline.py

### DIFF
--- a/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
+++ b/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
@@ -120,7 +120,7 @@ class StatisticsVolume(cpe.Pipeline):
         elif self.parameters["orig_input_data"] == "t1-volume":
             self.parameters["measure_label"] = "graymatter"
             information_dict = t1_volume_template_tpm_in_mni(
-                self.parameters["group_label_dartel"], 0, True
+                self.parameters["group_label_dartel"], 1, True
             )
 
         elif self.parameters["orig_input_data"] == "custom-pipeline":


### PR DESCRIPTION
Hi, 
I have found a potential bug in this file, when doing statistics-volume pipeline.
It appears the param tissu_number should be 1, not 0.  
When doing statistics-volume pipeline, clinica crashed, and report KeyError, with value 0.  

(clinicaEnv) ➜  clinica run statistics-volume CAPS_TEST ADvsHC t1-volume test_participants.tsv group

***********************
*** Clinica crashed ***
***********************

Exception type: KeyError
Exception value: 0
Below are displayed information that were gathered when Clinica crashed. This will help to understand what happened if you transfer those information to the Clinica development team.

=======================================================================================================================================================================
0 /Users/sungoku/miniconda3/envs/clinicaEnv/bin/clinica                                                                                   8   <module>                      sys.exit(execute())
1 /Users/sungoku/miniconda3/envs/clinicaEnv/lib/python3.7/site-packages/clinica/cmdline.py                                                652 execute                       args.func(args)
2 /Users/sungoku/miniconda3/envs/clinicaEnv/lib/python3.7/site-packages/clinica/pipelines/statistics_volume/statistics_volume_cli.py      200 run_command                   exec_pipeline = pipeline.run()
3 /Users/sungoku/miniconda3/envs/clinicaEnv/lib/python3.7/site-packages/clinica/pipelines/engine.py                                       274 run                           self.build()
4 /Users/sungoku/miniconda3/envs/clinicaEnv/lib/python3.7/site-packages/clinica/pipelines/engine.py                                       26  func_wrapper                  res = func(self, *args, **kwargs)
5 /Users/sungoku/miniconda3/envs/clinicaEnv/lib/python3.7/site-packages/clinica/pipelines/engine.py                                       243 build                         self.build_input_node()
6 /Users/sungoku/miniconda3/envs/clinicaEnv/lib/python3.7/site-packages/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py 123 build_input_node              self.parameters["group_label_dartel"], 0, True
7 /Users/sungoku/miniconda3/envs/clinicaEnv/lib/python3.7/site-packages/clinica/utils/input_files.py                                      244 t1_volume_template_tpm_in_mni f"*_T1w_segm-{INDEX_TISSUE_MAP[tissue_number]}_space-Ixi549Space_modulated-{pattern_modulation}_probability.nii*",
=======================================================================================================================================================================

INDEX_TISSUE_MAP in utils/spm.py has no 0 key, it starts from 1:graymatter.
please fix this bug.